### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,6 @@ my %WriteMakefileArgs = (
     "Scalar::Util" => 0,
     "parent" => 0,
     "strict" => 0,
-    "vars" => 0,
     "warnings" => 0
   },
   "TEST_REQUIRES" => {
@@ -52,7 +51,6 @@ my %FallbackPrereqs = (
   "lib" => 0,
   "parent" => 0,
   "strict" => 0,
-  "vars" => 0,
   "warnings" => 0
 );
 

--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,6 @@ requires "Params::Validate" => "0.72";
 requires "Scalar::Util" => "0";
 requires "parent" => "0";
 requires "strict" => "0";
-requires "vars" => "0";
 requires "warnings" => "0";
 
 on 'test' => sub {

--- a/lib/DateTime/Format/Builder.pm
+++ b/lib/DateTime/Format/Builder.pm
@@ -10,7 +10,7 @@ use DateTime 1.00;
 use Params::Validate 0.72 qw(
     validate SCALAR ARRAYREF HASHREF SCALARREF CODEREF GLOB GLOBREF UNDEF
 );
-use vars qw( %dispatch_data );
+our %dispatch_data;
 
 my $parser = 'DateTime::Format::Builder::Parser';
 

--- a/lib/DateTime/Format/Builder/Parser/Dispatch.pm
+++ b/lib/DateTime/Format/Builder/Parser/Dispatch.pm
@@ -5,7 +5,7 @@ use warnings;
 
 our $VERSION = '0.83';
 
-use vars qw( %dispatch_data );
+our %dispatch_data;
 use Params::Validate qw( CODEREF validate );
 use DateTime::Format::Builder::Parser;
 

--- a/lib/DateTime/Format/Builder/Parser/Quick.pm
+++ b/lib/DateTime/Format/Builder/Parser/Quick.pm
@@ -5,7 +5,7 @@ use warnings;
 
 our $VERSION = '0.83';
 
-use vars qw( %dispatch_data );
+our %dispatch_data;
 
 use Params::Validate qw( SCALAR OBJECT CODEREF validate );
 


### PR DESCRIPTION
"our" is already in use so we're clearly comfortable with v5.6.0+